### PR TITLE
Small fixes to printer control card

### DIFF
--- a/src/cards/print-control-card/card.styles.ts
+++ b/src/cards/print-control-card/card.styles.ts
@@ -3,7 +3,7 @@ import { css } from "lit";
 export default css`
   /* Styling for the 'alpha' text */
   .alpha-text {
-    position: absolute; /* Position it absolutely within the card */
+    position: absolute;  /* Position it absolutely within the card */
     top: 10px;           /* 10px from the top */
     right: 10px;         /* 10px from the right */
     color: red;          /* Red text */
@@ -19,14 +19,14 @@ export default css`
     cursor: pointer;
   }
   button:disabled {
-    background-color: #ccc;  /* Light grey background when disabled */
-    color: #666;  /* Dark grey text */
-    cursor: not-allowed;  /* Change cursor to indicate it's not clickable */
+    background-color: #ccc;   /* Light grey background when disabled */
+    color: #666;              /* Dark grey text */
+    cursor: not-allowed;      /* Change cursor to indicate it's not clickable */
   }
   .button-container {
     display: flex;
     justify-content: flex-end;  /* This will align the buttons to the right */
-    gap: 10px;  /* Optional: Adds space between buttons */
+    gap: 10px;                  /* Optional: Adds space between buttons */
   }
   .canvas {
     display: block;
@@ -61,11 +61,9 @@ export default css`
   .popup-header {
     font-size: 18px;
     margin-bottom: 10px;
-    /*color: black; /* Ensure the header text is black */
   }
   .popup-content {
     font-size: 14px;
-    /*color: black; /* Ensure the content text is black */
   }
   /* Remove bullets from the list */
   #checkboxList {

--- a/src/cards/print-control-card/card.styles.ts
+++ b/src/cards/print-control-card/card.styles.ts
@@ -43,7 +43,7 @@ export default css`
     top: 100%;
     left: 50%;
     transform: translateX(-50%);
-    background: white;
+    background-color: var(--card-background-color, white);
     padding: 20px;
     border: 1px solid #ccc;
     box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
@@ -61,11 +61,11 @@ export default css`
   .popup-header {
     font-size: 18px;
     margin-bottom: 10px;
-    color: black; /* Ensure the header text is black */
+    /*color: black; /* Ensure the header text is black */
   }
   .popup-content {
     font-size: 14px;
-    color: black; /* Ensure the content text is black */
+    /*color: black; /* Ensure the content text is black */
   }
   /* Remove bullets from the list */
   #checkboxList {

--- a/src/cards/print-control-card/const.ts
+++ b/src/cards/print-control-card/const.ts
@@ -3,4 +3,4 @@ import { PREFIX_NAME } from "../../const";
 export const PRINT_CONTROL_CARD_NAME = `${PREFIX_NAME}-skipobject-card`;
 export const PRINT_CONTROL_CARD_EDITOR_NAME = `${PRINT_CONTROL_CARD_NAME}-editor`;
 export const PRINT_CONTROL_CARD_ENTITY_DOMAINS = ["bambu_lab"];
-export const PRINTER_MODELS = ["A1", "A1 Mini", "P1P", "P1S", "X1C", "X1E"];
+export const PRINTER_MODELS = ["A1", "A1 MINI", "A1 Mini", "A1MINI", "A1Mini", "P1P", "P1S", "X1C", "X1E"];

--- a/src/cards/print-control-card/print-control-card.ts
+++ b/src/cards/print-control-card/print-control-card.ts
@@ -342,12 +342,12 @@ export class PrintControlCard extends LitElement {
           <button class="button" @click="${() => this._clickButton(this._entities?.stop)}" ?disabled="${this._isEntityUnavailable(this._entities?.stop)}">
             Stop
           </button>
-          <button class="button" @click="${this._togglePopup}" ?disabled="${this._isEntityUnavailable(this._entities?.stop)}">
+          <button class="button" @click="${this._showPopup}" ?disabled="${this._isEntityUnavailable(this._entities?.stop)}">
             Skip
           </button>
         </div>
         <div class="popup-container" style="display: ${this._popupVisible ? 'block' : 'none'};">
-          <div class="popup-background" @click="${this._togglePopup}"></div>
+          <div class="popup-background" @click="${this._cancelPopup}"></div>
           <div class="popup">
             <div class="popup-header">Skip Objects</div>
             <div class="alpha-text">Alpha</div>
@@ -368,7 +368,7 @@ export class PrintControlCard extends LitElement {
               </div>
               <p>Select the object(s) you want to skip printing.</p>
               <div class="button-container">
-                <button class="button" @click="${this._togglePopup}">
+                <button class="button" @click="${this._cancelPopup}">
                   Cancel
                 </button>
                 <button class="button" @click="${this._callSkipObjectsService}" ?disabled="${this._isSkipButtonDisabled}">
@@ -382,9 +382,19 @@ export class PrintControlCard extends LitElement {
     `;
   }
 
-  // Function to toggle popup visibility
-  private _togglePopup() {
-    this._popupVisible = !this._popupVisible;
+  // Functions to toggle popup visibility
+  private _showPopup() {
+    this._popupVisible = true;
+  }
+  private _cancelPopup() {
+    this._popupVisible = false;
+    // Now reset all the to_skip to the existing skipped state.
+    let objects = new Map<number, PrintableObject>();
+    this._objects.forEach((value, key) => {
+      value.to_skip = value.skipped;
+      objects.set(key, value);
+    });
+    this._objects = objects;
   }
 
   // Method to check if the skip button should be disabled


### PR DESCRIPTION
Fix printer control card so it works with dark themes.
Fix printer config to accept A1 Mini printers. Since there's at least two versions of how the model got persisted I just added all the possible versions and capitalizations.
Fix card to reset skip choices when cancelled/dismissed.
