### PR TITLE
Fix broken print status card in card picker by removing unnecessary async initialization.

### DIFF
--- a/src/cards/print-control-card/print-control-card.ts
+++ b/src/cards/print-control-card/print-control-card.ts
@@ -385,7 +385,11 @@ export class PrintControlCard extends LitElement {
   }
 
   private _getSpeedProfile() {
-    return helpers.getLocalizedEntityState(this._hass, this._entityList['speed_profile'])
+    if (this._entityList['speed_profile']) {
+      return helpers.getLocalizedEntityState(this._hass, this._entityList['speed_profile'])
+    } else {
+      return '';
+    }
   }
 
   render() {

--- a/src/cards/print-control-card/print-control-card.ts
+++ b/src/cards/print-control-card/print-control-card.ts
@@ -112,13 +112,10 @@ export class PrintControlCard extends LitElement {
         })
       }
 
-      helpers.asyncFilterBambuDevices(hass, this._device_id, ENTITYLIST).then(
-        result => {
-          this._entityList = result;
-          // Keep a reference to the skippedObjects state for Lit reactivity to trigger off when it changes.
-          this._pickImageState = this._states[result['pick_image'].entity_id].state;
-          this._skippedObjectsState = this._states[result['skipped_objects'].entity_id].state;
-        })
+      this._entityList = helpers.getBambuDeviceEntities(hass, this._device_id, ENTITYLIST);
+      // Keep a reference to the skippedObjects state for Lit reactivity to trigger off when it changes.
+      this._pickImageState = this._states[this._entityList['pick_image'].entity_id].state;
+      this._skippedObjectsState = this._states[this._entityList['skipped_objects'].entity_id].state;
     }
   }
 

--- a/src/cards/print-control-card/print-control-card.ts
+++ b/src/cards/print-control-card/print-control-card.ts
@@ -179,32 +179,23 @@ export class PrintControlCard extends LitElement {
   }
 
   private _getPickImageUrl() {
-    if (this._entityList['pick_image']) {
-      const entity = this._entityList['pick_image'];
-      const timestamp = this._states[entity.entity_id].state;
-      const accessToken = this._states[entity.entity_id].attributes?.access_token
-      const imageUrl = `/api/image_proxy/${entity.entity_id}?token=${accessToken}&time=${timestamp}`;
-      return imageUrl;
-    }
-    return '';
+    const entity = this._entityList['pick_image'];
+    const timestamp = this._states[entity.entity_id].state;
+    const accessToken = this._states[entity.entity_id].attributes?.access_token
+    const imageUrl = `/api/image_proxy/${entity.entity_id}?token=${accessToken}&time=${timestamp}`;
+    return imageUrl;
   }
 
   private _getSkippedObjects() {
-    if (this._entityList['skipped_objects']) {
-      const entity = this._entityList['skipped_objects'];
-      const value = this._states[entity.entity_id].attributes['objects'];
-      return value
-    }
-    return null;
+    const entity = this._entityList['skipped_objects'];
+    const value = this._states[entity.entity_id].attributes['objects'];
+    return value
   }
 
   private _getPrintableObjects() {
-    if (this._entityList['printable_objects']) {
-      const entity = this._entityList['printable_objects'];
-      const value = this._states[entity.entity_id].attributes['objects'];
-      return value
-    }
-    return null;
+    const entity = this._entityList['printable_objects'];
+    const value = this._states[entity.entity_id].attributes['objects'];
+    return value
   }
 
   private _isEntityUnavailable(entity: helpers.Entity): boolean {
@@ -382,11 +373,7 @@ export class PrintControlCard extends LitElement {
   }
 
   private _getSpeedProfile() {
-    if (this._entityList['speed_profile']) {
-      return helpers.getLocalizedEntityState(this._hass, this._entityList['speed_profile'])
-    } else {
-      return '';
-    }
+    return helpers.getLocalizedEntityState(this._hass, this._entityList['speed_profile'])
   }
 
   render() {

--- a/src/cards/print-status-card/print-status-card.ts
+++ b/src/cards/print-status-card/print-status-card.ts
@@ -200,20 +200,13 @@ export class PrintControlCard extends LitElement {
         this._model = 'A1MINI';
       }
       this._entityUX = this.EntityUX[this._model];
-      // Now trigger the load of the entity data.
-      helpers.asyncFilterBambuDevices(hass, this._device_id, Object.keys(this._entityUX!)).then(
-        result => {
-          this._entityList = result;
-          // Object.keys(result).forEach((key) => {
-          //   this._entities.push(this._states[result[key].entity_id]);
-          // });
-          //this._lightbulb = this._states[result['chamber_light'].entity_id].state;
-          //console.log(this._lightbulb)
-          this._createEntityElements();
+      this._entityList = helpers.getBambuDeviceEntities(hass, this._device_id, Object.keys(this._entityUX!));
 
-          // We have the model and the chamber light entity - kick off the background image load.
-          this.requestUpdate();
-        })
+      // We have the model and the chamber light entity - kick off the background image load asap.
+      this.requestUpdate();
+
+      // Now we create the html elements for the entities.
+      this._createEntityElements();
     }
   }
 

--- a/src/cards/print-status-card/print-status-card.ts
+++ b/src/cards/print-status-card/print-status-card.ts
@@ -195,7 +195,6 @@ export class PrintControlCard extends LitElement {
 
     if (firstTime) {
       this._model = this._hass.devices[this._device_id].model.toUpperCase();
-      console.log("Model is", this._model)
       if (this._model == 'A1 MINI') {
         this._model = 'A1MINI';
       }
@@ -229,18 +228,14 @@ export class PrintControlCard extends LitElement {
   }
 
   private _getPrinterImage() {
-    if (this._entityList['chamber_light']) {
-      const lightOn = helpers.getEntityState(this._hass, this._entityList['chamber_light']) == 'on'
-      if (lightOn) {
-        return _onImages[this._model]
-      }
-      else {
-        return _offImages[this._model]
-      }
-    } else {
-      return '';
+    const lightOn = helpers.getEntityState(this._hass, this._entityList['chamber_light']) == 'on'
+    if (lightOn) {
+      return _onImages[this._model]
     }
-  }
+    else {
+      return _offImages[this._model]
+    }
+}
 
   private _createEntityElements() {
     const container = this.shadowRoot?.getElementById('container')!;

--- a/src/cards/print-status-card/print-status-card.ts
+++ b/src/cards/print-status-card/print-status-card.ts
@@ -195,12 +195,11 @@ export class PrintControlCard extends LitElement {
 
     if (firstTime) {
       this._model = this._hass.devices[this._device_id].model.toUpperCase();
+      console.log("Model is", this._model)
       if (this._model == 'A1 MINI') {
         this._model = 'A1MINI';
       }
       this._entityUX = this.EntityUX[this._model];
-      // We have the model - kick off the background image load asap.
-      this.requestUpdate();
       // Now trigger the load of the entity data.
       helpers.asyncFilterBambuDevices(hass, this._device_id, Object.keys(this._entityUX!)).then(
         result => {
@@ -211,6 +210,9 @@ export class PrintControlCard extends LitElement {
           //this._lightbulb = this._states[result['chamber_light'].entity_id].state;
           //console.log(this._lightbulb)
           this._createEntityElements();
+
+          // We have the model and the chamber light entity - kick off the background image load.
+          this.requestUpdate();
         })
     }
   }
@@ -234,12 +236,16 @@ export class PrintControlCard extends LitElement {
   }
 
   private _getPrinterImage() {
-    const lightOn = helpers.getEntityState(this._hass, this._entityList['chamber_light']) == 'on'
-    if (lightOn) {
-      return _onImages[this._model]
-    }
-    else {
-      return _offImages[this._model]
+    if (this._entityList['chamber_light']) {
+      const lightOn = helpers.getEntityState(this._hass, this._entityList['chamber_light']) == 'on'
+      if (lightOn) {
+        return _onImages[this._model]
+      }
+      else {
+        return _offImages[this._model]
+      }
+    } else {
+      return '';
     }
   }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -49,17 +49,15 @@ export interface Entity {
   name: string;
 }
 
-export async function asyncFilterBambuDevices(hass, device_id, entities: string[]): Promise<{ [key: string]: Entity }> {
+export function getBambuDeviceEntities(hass, device_id, entities: string[]): { [key: string]: Entity } {
   const result: { [key: string]: Entity } = {}
   // Loop through all hass entities, and find those that belong to the selected device
   for (let k in hass.entities) {
     const value = hass.entities[k];
     if (value.device_id === device_id) {
-      const r = await asyncGetEntity(hass, value.entity_id);
       for (const key of entities) {
-        const regex = new RegExp(`^[^_]+_${key}$`);
-        if (regex.test(r.unique_id)) {
-          result[key] = r
+        if (key == value.translation_key) {
+          result[key] = value
         }
       };
     }


### PR DESCRIPTION
## Description

We were doing an async lookup of a the unique_id and then comparing just the last portion of it ignoring the serial - but that's just the translation_key since that's how we build the unique_id in code and we already have that on the entity list hass makes directly available to us. So just use the translation_key directly to match the elements we want to identify. This eliminates repetitive problems where we misbehave because the code is trying to render while we're still not fully initialized.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed
- [ ] There are no tests

## Additional Notes

<!-- Add any additional information that reviewers should know -->
