### PR TITLE
Use HA entities consistently so we can access precision and show more info

### DIFF
--- a/src/cards/ams-card/ams-card.ts
+++ b/src/cards/ams-card/ams-card.ts
@@ -1,7 +1,7 @@
+import * as helpers from "../../utils/helpers"
 import { customElement, state } from "lit/decorators.js";
 import { html, LitElement, nothing } from "lit";
 
-import * as helpers from "../../utils/helpers"
 import { registerCustomCard } from "../../utils/custom-cards";
 import { INTEGRATION_DOMAIN, MANUFACTURER, AMS_MODELS } from "../../const";
 import { AMS_CARD_EDITOR_NAME, AMS_CARD_NAME  } from "./const";
@@ -35,7 +35,6 @@ interface Sensor {
 }
 
 interface Result {
-  custom_humidity: Sensor | null;
   humidity: Sensor;
   temperature: Sensor | null;
   spools: Sensor[];
@@ -116,18 +115,18 @@ export class AMS_CARD extends LitElement {
       this._entityList = helpers.getBambuDeviceEntities(hass, this._deviceId, ENTITYLIST);
 
       // Set custom entities
-      for (const e in hass.entities) {
-        const value = hass.entities[e];
+      for (const key in hass.entities) {
+        const value = hass.entities[key];
         if (value.entity_id === this._customTemperature) {
           this._entityList['ams_temp'] = value; // Replace normal temp sensor, if present.
-        } else if (value.entity_id === this._customHumidity) {
-          this._entityList['custom_humidity'] = value;
+        }
+        if (value.entity_id === this._customHumidity) {
+          this._entityList['humidity_index'] = value; // Replace normal humidity_index sensor.
         }
       }
 
       // Convert data to form rest of the cards are expecting.
       this._entities = {
-        customHumidity: this._entityList['custom_humidity'],
         humidity: this._entityList['humidity_index'],
         temperature: this._entityList['ams_temp'],
         spools: [ this._entityList['tray_1'], this._entityList['tray_2'], this._entityList['tray_3'], this._entityList['tray_4']],
@@ -142,7 +141,7 @@ export class AMS_CARD extends LitElement {
         <graphic-ams-card
           .subtitle="${this._subtitle}"
           .entities="${this._entities}"
-          .states="${this._states}"
+          .hass="${this._hass}"
           .showInfoBar=${this._showInfoBar}
         />
       `;
@@ -151,7 +150,7 @@ export class AMS_CARD extends LitElement {
         <vector-ams-card
           .subtitle="${this._subtitle}"
           .entities="${this._entities}"
-          .states="${this._states}"
+          .hass="${this._hass}"
           .showInfoBar=${this._showInfoBar}
           .showType=${this._showType}
         />
@@ -180,31 +179,6 @@ export class AMS_CARD extends LitElement {
       entity_id: entity_id,
     });
   }
-
-  // private async filterBambuDevices() {
-  //   const result: Result = {
-  //     humidity: null,
-  //     temperature: null,
-  //     spools: [],
-  //     type: (await this.getDeviceModel()) ?? null,
-  //   };
-  //   // Loop through all hass entities, and find those that belong to the selected device
-  //   for (let key in this._hass.entities) {
-  //     const value = this._hass.entities[key];
-  //     if (value.device_id === this._deviceId) {
-  //       const r = await this.getEntity(value.entity_id);
-  //       if (r.unique_id.includes("humidity")) {
-  //         result.humidity = value;
-  //       } else if (r.unique_id.includes("temp")) {
-  //         result.temperature = value;
-  //       } else if (r.unique_id.includes("tray")) {
-  //         result.spools.push(value);
-  //       }
-  //     }
-  //   }
-
-  //   this._entities = result;
-  // }
 
   private async getDeviceModel() {
     if (!this._deviceId) return;

--- a/src/cards/ams-card/components/info-bar/info-bar.ts
+++ b/src/cards/ams-card/components/info-bar/info-bar.ts
@@ -65,7 +65,6 @@ export class InfoBar extends LitElement {
     let value = state.state;
     if (this.temperature.display_precision != undefined) {
       value = Number(value).toFixed(this.temperature.display_precision);
-      console.log(value)
     }
     return `${value}${state.attributes.unit_of_measurement}`
   }

--- a/src/cards/ams-card/components/info-bar/info-bar.ts
+++ b/src/cards/ams-card/components/info-bar/info-bar.ts
@@ -60,6 +60,19 @@ export class InfoBar extends LitElement {
     }
   }
 
+  private getHumidity(): String {
+    const state = this.hass.states[this.humidity.entity_id];
+    let value = state.state;
+    if (this.humidity.display_precision != undefined) {
+      value = Number(value).toFixed(this.humidity.display_precision);
+    }
+    if (this.humidity.translation_key != 'humidity_index') {
+      value += '%'
+    }
+    return value
+  }
+
+
   private getTemperature(): String {
     const state = this.hass.states[this.temperature.entity_id];
     let value = state.state;
@@ -79,8 +92,7 @@ export class InfoBar extends LitElement {
               <div class="info" @click="${() => helpers.showEntityMoreInfo(this, this.humidity)}">
                 <span><ha-icon icon="mdi:water" style="color: ${this.getHumidityColor()}" /></span>
                 <span>
-                  ${this.hass.states[this.humidity.entity_id].state}
-                  ${this.humidity.translation_key == 'humidity_index' ? '': '%'}
+                  ${this.getHumidity()}
                 </span>
               </div>`
             : nothing}

--- a/src/cards/ams-card/components/info-bar/info-bar.ts
+++ b/src/cards/ams-card/components/info-bar/info-bar.ts
@@ -1,17 +1,20 @@
+import * as helpers from "../../../../utils/helpers"
 import { customElement, property } from "lit/decorators.js";
 import { html, LitElement, nothing } from "lit";
 import styles from "./info-bar.styles";
 
 @customElement("info-bar")
 export class InfoBar extends LitElement {
+  @property({ type: Object }) public hass;
   @property({ type: String }) public subtitle;
   @property({ type: Object }) public humidity;
   @property({ type: Object }) public temperature;
 
   static styles = styles;
 
-  getHumidityColor() {
-    switch (this.humidity) {
+  private getHumidityColor(): String {
+    const state = this.hass.states[this.humidity.entity_id];
+    switch (state.state) {
       case "1":
         return "#e0f7fa"; // very light blue
       case "2":
@@ -27,10 +30,11 @@ export class InfoBar extends LitElement {
     }
   }
 
-  getTemperatureColor() {
+  private getTemperatureColor(): String {
     // Ensure temperature is within 0–30 if you want to clamp out-of-range values:
-    let temp = parseFloat(this.temperature.value);
-    const unit = this.temperature.unit_of_measurement;
+    const state = this.hass.states[this.temperature.entity_id];
+    let temp = parseFloat(state.state);
+    const unit = state.attributes.unit_of_measurement;
 
     if (unit !== "°C") {
       temp = ((temp - 32) * 5) / 9;
@@ -56,33 +60,40 @@ export class InfoBar extends LitElement {
     }
   }
 
+  private getTemperature(): String {
+    const state = this.hass.states[this.temperature.entity_id];
+    let value = state.state;
+    if (this.temperature.display_precision != undefined) {
+      value = Number(value).toFixed(this.temperature.display_precision);
+      console.log(value)
+    }
+    return `${value}${state.attributes.unit_of_measurement}`
+  }
+
   render() {
     return html`
       <div class="extra-info">
         <div class="subtitle">${this.subtitle}</div>
         <div class="info-slots">
           ${this.humidity
-            ? html` <div class="info">
+            ? html`
+              <div class="info" @click="${() => helpers.showEntityMoreInfo(this, this.humidity)}">
                 <span><ha-icon icon="mdi:water" style="color: ${this.getHumidityColor()}" /></span>
-                <span
-                  >${this.humidity.type == "custom"
-                    ? this.humidity.value + "%"
-                    : this.humidity.value}</span
-                >
+                <span>
+                  ${this.hass.states[this.humidity.entity_id].state}
+                  ${this.humidity.translation_key == 'humidity_index' ? '': '%'}
+                </span>
               </div>`
             : nothing}
           ${this.temperature
             ? html`
-                <div class="info">
+                <div class="info" @click="${() => helpers.showEntityMoreInfo(this, this.temperature)}">
                   <span>
-                    <ha-icon icon="mdi:thermometer" style="color: ${this.getTemperatureColor()}" />
+                    <ha-icon icon="mdi:thermometer" style="color: ${this.getTemperatureColor()}"></ha-icon>
                   </span>
-                  <span
-                    >${this.temperature.type == "custom"
-                      ? this.temperature.value
-                      : this.temperature.value}
-                    ${this.temperature.unit_of_measurement}</span
-                  >
+                  <span>
+                    ${this.getTemperature()}
+                  </span>
                 </div>
               `
             : nothing}

--- a/src/cards/ams-card/graphic-ams-card/graphic-ams-card.ts
+++ b/src/cards/ams-card/graphic-ams-card/graphic-ams-card.ts
@@ -1,3 +1,4 @@
+import * as helpers from "../../../utils/helpers"
 import { customElement, property } from "lit/decorators.js";
 import { html, LitElement, nothing } from "lit";
 import styles from "./graphic-ams-card.styles";
@@ -8,38 +9,9 @@ export class GraphicAmsCard extends LitElement {
   @property() public subtitle;
   @property() public showInfoBar;
   @property({ type: Object }) public entities;
-  @property({ type: Object }) public states;
-  @property() public customHumidity;
-  @property() public customTemperature;
+  @property({ type: Object }) public hass;
 
   static styles = styles;
-  temperature() {
-    if (this.entities.temperature) {
-      return {
-        type: "default",
-        value: this.states[this.entities.temperature.entity_id].state,
-        unit_of_measurement:
-          this.states[this.entities.temperature.entity_id].attributes.unit_of_measurement,
-      };
-    }
-    return nothing;
-  }
-
-  humidity() {
-    if (this.entities.customHumidity) {
-      return {
-        type: "custom",
-        value: this.states[this.entities.customHumidity.entity_id].state,
-      };
-    }
-    if (this.entities.humidity) {
-      return {
-        type: "default",
-        value: this.states[this.entities.humidity.entity_id].state,
-      };
-    }
-    return nothing;
-  }
 
   render() {
     return html` <ha-card class="card">
@@ -47,8 +19,9 @@ export class GraphicAmsCard extends LitElement {
         ${this.showInfoBar
           ? html`<info-bar
               subtitle="${this.subtitle}"
-              .humidity="${this.humidity()}"
-              .temperature="${this.temperature()}"
+              .hass="${this.hass}"
+              .humidity="${this.entities.humidity}"
+              .temperature="${this.entities.temperature}"
             ></info-bar>`
           : nothing}
         <div class="ams-container">
@@ -59,16 +32,16 @@ export class GraphicAmsCard extends LitElement {
                 <div class="spool-info">
                   <span
                     class="spool-badge"
-                    style="border: ${this.states[spool.entity_id]?.attributes.active ||
-                    this.states[spool.entity_id]?.attributes.in_use
-                      ? `2px solid ${this.states[spool.entity_id]?.attributes.color}`
+                    style="border: ${this.hass.states[spool.entity_id]?.attributes.active ||
+                    this.hass.states[spool.entity_id]?.attributes.in_use
+                      ? `2px solid ${this.hass.states[spool.entity_id]?.attributes.color}`
                       : `2px solid rgba(255, 255, 255, 0)`}"
                   >
                     <ha-icon
-                      icon=${this.states[spool.entity_id].state !== "Empty"
+                      icon=${this.hass.states[spool.entity_id].state !== "Empty"
                         ? "mdi:printer-3d-nozzle"
                         : "mdi:tray"}
-                      style="color: ${this.states[spool.entity_id]?.attributes.color};"
+                      style="color: ${this.hass.states[spool.entity_id]?.attributes.color};"
                     >
                     </ha-icon>
                   </span>
@@ -76,10 +49,10 @@ export class GraphicAmsCard extends LitElement {
                 <div class="spool-info">
                   <span
                     class="spool-type"
-                    style="border: ${this.states[spool.entity_id]?.attributes.active
-                      ? `2px solid ${this.states[spool.entity_id]?.attributes.color}`
+                    style="border: ${this.hass.states[spool.entity_id]?.attributes.active
+                      ? `2px solid ${this.hass.states[spool.entity_id]?.attributes.color}`
                       : `2px solid rgba(255, 255, 255, 0)`};"
-                    >${this.states[spool.entity_id]?.attributes.type}</span
+                    >${this.hass.states[spool.entity_id]?.attributes.type}</span
                   >
                 </div>
               </div>

--- a/src/cards/ams-card/vector-ams-card/vector-ams-card.ts
+++ b/src/cards/ams-card/vector-ams-card/vector-ams-card.ts
@@ -1,3 +1,4 @@
+import * as helpers from "../../../utils/helpers"
 import { customElement, property } from "lit/decorators.js";
 import { html, LitElement, nothing } from "lit";
 import styles from "./vector-ams-card.styles";
@@ -8,40 +9,10 @@ export class VectorAmsCard extends LitElement {
   @property() public subtitle;
   @property() public showInfoBar;
   @property({ type: Object }) public entities;
-  @property({ type: Object }) public states;
   @property() public showType;
-  @property() public customHumidity;
-  @property() public customTemperature;
+  @property() public hass;
 
   static styles = styles;
-
-  temperature() {
-    if (this.entities.temperature) {
-      return {
-        type: "default",
-        value: this.states[this.entities.temperature.entity_id].state,
-        unit_of_measurement:
-          this.states[this.entities.temperature.entity_id]?.attributes.unit_of_measurement,
-      };
-    }
-    return nothing;
-  }
-
-  humidity() {
-    if (this.entities.customHumidity) {
-      return {
-        type: "custom",
-        value: this.states[this.entities.customHumidity.entity_id].state,
-      };
-    }
-    if (this.entities.humidity) {
-      return {
-        type: "default",
-        value: this.states[this.entities.humidity.entity_id].state,
-      };
-    }
-    return nothing;
-  }
 
   isActive(attributes) {
     if (attributes?.active || attributes?.in_use) return true;
@@ -62,8 +33,9 @@ export class VectorAmsCard extends LitElement {
           ${this.showInfoBar
             ? html` <info-bar
                 subtitle="${this.subtitle}"
-                .humidity="${this.humidity()}"
-                .temperature="${this.temperature()}"
+                .hass="${this.hass}"
+                .humidity="${this.entities.humidity}"
+                .temperature="${this.entities.temperature}"
               ></info-bar>`
             : nothing}
           <div class="v-ams-container">
@@ -71,12 +43,13 @@ export class VectorAmsCard extends LitElement {
               (spool: { entity_id: string | number }) => html`
                 <ha-bambulab-spool
                   style="padding: 0px 5px"
-                  ?active="${this.isActive(this.states[spool.entity_id]?.attributes)}"
-                  .color="${this.states[spool.entity_id]?.attributes.color}"
-                  .name="${this.states[spool.entity_id]?.attributes.name}"
-                  .tag_uid="${this.states[spool.entity_id]?.attributes.tag_uid}"
+                  .hass="${this.hass}"
+                  ?active="${this.isActive(this.hass.states[spool.entity_id]?.attributes)}"
+                  .color="${this.hass.states[spool.entity_id]?.attributes.color}"
+                  .name="${this.hass.states[spool.entity_id]?.attributes.name}"
+                  .tag_uid="${this.hass.states[spool.entity_id]?.attributes.tag_uid}"
                   .remaining="${this.remainingModifier(
-                    this.states[spool.entity_id]?.attributes.remain
+                    this.hass.states[spool.entity_id]?.attributes.remain
                   )}"
                   .show_type=${this.showType}
                 ></ha-bambulab-spool>

--- a/src/cards/print-control-card/print-control-card.ts
+++ b/src/cards/print-control-card/print-control-card.ts
@@ -409,7 +409,7 @@ export class PrintControlCard extends LitElement {
           </div>
           <div class="buttons-container">
             <ha-button class="ha-button" @click="${this._showPopup}" ?disabled="${!this._enableSkipButton()}" style="display: ${this._showSkipButton() ? 'block' : 'none'};">
-              <ha-icon icon="mdi:skip-forward"></ha-icon>
+              <ha-icon icon="mdi:debug-step-over"></ha-icon>
             </ha-button>
             <ha-button class="ha-button" @click="${this._showPauseDialog}" ?disabled="${this._isEntityUnavailable(this._entityList['pause'])}">
               <ha-icon icon="mdi:pause"></ha-icon>


### PR DESCRIPTION
… info

## Description

Align the AMS cards with how I'm doing things in the printer cards. By passing full HA entities throughout we have access to the full information about them and their states - such as translation_key, precision, unit_of_measurement rather than just a subset. It also allows us to then simply pass custom entities around in place of the default ones and still special case them (e.g. add % to a custom humidity sensor value).

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
