### PR TITLE
feat: display door open/closed if present

### DIFF
--- a/src/cards/print-status-card/print-status-card.ts
+++ b/src/cards/print-status-card/print-status-card.ts
@@ -166,6 +166,7 @@ export class PrintControlCard extends LitElement {
     bed_temp:               { x: 50, y:88,   width:25,  height:0, alternate:"target_bed_temperature" },
     target_bed_temperature:    undefined,
     stage:                  { x: 50, y:95, width:300, height:0 },
+    door_open:              { x: 86, y:60,   width:20, height:0 },
   };
 
   private EntityUX: { [key: string]: any } = {
@@ -475,6 +476,13 @@ export class PrintControlCard extends LitElement {
           return html`
             <div id="${key}" class="entity" style="${style}">
               ${helpers.formatMinutes(Number(text))}
+            </div>`;
+
+        case 'door_open':
+          const icon = (text == 'on') ? 'mdi:door-open' : 'mdi:door-closed';
+          return html`
+            <div id="${key}" class="entity" style="${style}" @click="${() => this._clickEntity(clickTarget)}">
+              <ha-icon icon="${icon}"></ha-icon>
             </div>`;
 
         default:


### PR DESCRIPTION
## Description

This will display the door open / door closed icon if the sensor is present in the status card.
This is useful so you can see remotely if you left the door open or closed for PLA vs other materials.
<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
