### PR TITLE
Fix missing cover image updates

### DIFF
--- a/src/cards/print-status-card/print-status-card.ts
+++ b/src/cards/print-status-card/print-status-card.ts
@@ -508,10 +508,11 @@ export class PrintControlCard extends LitElement {
 
   private _getCoverImageUrl() {
     if (helpers.isEntityUnavailable(this._hass, this._entityList['cover_image'])) {
+      console.log("Cover image unavailable")
       return '';
     } else {
       const coverImageEntityId = this._entityList['cover_image'].entity_id;
-      return this._hass.states[coverImageEntityId].attributes.entity_picture;
+      return `${this._hass.states[coverImageEntityId].attributes.entity_picture}&state=${this._coverImageState}`;
     }
   }
 


### PR DESCRIPTION
## Description

The image URL returned by HA doesn't change when it goes from broken to working. So after we encounter a load error, we need to add something to break the caching to try again. The obvious thing is the sensor state since that changes only when the image content has changes/become unavailable. So now we add that as an extra parameter to the URL and image now reloads instantly when it changes.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
