### PR TITLE
Fix font

### DIFF
--- a/src/cards/shared-components/ams-popup/ams-popup.styles.ts
+++ b/src/cards/shared-components/ams-popup/ams-popup.styles.ts
@@ -19,7 +19,6 @@ export default css`
   }
 
   .section-title {
-    font-family: "Inter";
     font-style: normal;
     font-weight: 700;
     font-size: 16px;
@@ -30,7 +29,6 @@ export default css`
   }
 
   .item-title {
-    font-family: "Inter";
     font-style: normal;
     font-weight: 400;
     font-size: 16px;
@@ -41,7 +39,6 @@ export default css`
   }
 
   .item-value {
-    font-family: "Inter";
     font-style: normal;
     font-weight: 400;
     font-size: 16px;

--- a/src/cards/shared-components/spool/spool.styles.ts
+++ b/src/cards/shared-components/spool/spool.styles.ts
@@ -213,7 +213,6 @@ export default css`
   }
 
   .section-title {
-    font-family: "Inter";
     font-style: normal;
     font-weight: 700;
     font-size: 16px;
@@ -224,7 +223,6 @@ export default css`
   }
 
   .item-title {
-    font-family: "Inter";
     font-style: normal;
     font-weight: 400;
     font-size: 16px;
@@ -235,7 +233,6 @@ export default css`
   }
 
   .item-value {
-    font-family: "Inter";
     font-style: normal;
     font-weight: 400;
     font-size: 16px;


### PR DESCRIPTION
## Description

'inter' gives a serif font on Windows 10/11 (Edge) and on iPhone. Remove it and inherit the font from HA styling.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
