### PR TITLE
Quick improvement for control card buttons overflowing

### DIFF
--- a/src/cards/print-control-card/card.styles.ts
+++ b/src/cards/print-control-card/card.styles.ts
@@ -24,7 +24,7 @@ export default css`
 .buttons-container {
   display: flex;
   justify-content: flex-end;
-  gap: 10px;
+  gap: 0px;
 }
 #canvas {
   position: absolute;


### PR DESCRIPTION
## Description

Remove the inter-button padding. They were too widely spaced anyway.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
