### PR TITLE
Fix oversized A1 cover image

### DIFF
--- a/src/cards/print-status-card/print-status-card.ts
+++ b/src/cards/print-status-card/print-status-card.ts
@@ -83,74 +83,74 @@ export class PrintStatusCard extends EntityProvider {
 
   private A1EntityUX: { [key: string]: EntityUX | undefined } = {
     //hms:                    { x: 90, y:10, width:20,  height:0 },
-    power: { x: 95, y: 9, width: 20, height: 0 },
-    chamber_light: { x: 46, y: 30, width: 20, height: 0 },
-    nozzle_temp: { x: 46, y: 42, width: 25, height: 0, click_target: "target_nozzle_temperature" },
-    cover_image: { x: 46, y: 60, width: 250, height: 250 },
-    bed_temp: { x: 46, y: 81, width: 25, height: 0, click_target: "target_bed_temperature" },
-    print_progress: { x: 85, y: 81, width: 25, height: 0 },
-    remaining_time: { x: 85, y: 85, width: 100, height: 0 },
-    stage: { x: 46, y: 92.5, width: 300, height: 0 },
+    power:          { x: 95, y: 9,    width: 20,  height: 0 },
+    chamber_light:  { x: 46, y: 30,   width: 20,  height: 0 },
+    nozzle_temp:    { x: 46, y: 42,   width: 25,  height: 0, click_target: "target_nozzle_temperature" },
+    cover_image:    { x: 46, y: 60,   width: 42,  height: 42 },
+    bed_temp:       { x: 46, y: 81,   width: 25,  height: 0, click_target: "target_bed_temperature" },
+    print_progress: { x: 85, y: 81,   width: 25,  height: 0 },
+    remaining_time: { x: 85, y: 85,   width: 100, height: 0 },
+    stage:          { x: 46, y: 92.5, width: 300, height: 0 },
   };
 
   private A1MiniEntityUX: { [key: string]: EntityUX | undefined } = {
     //hms:                    { x: 90, y:10, width:20,  height:0 },
-    power: { x: 95, y: 9, width: 20, height: 0 },
-    chamber_light: { x: 88, y: 29, width: 20, height: 0 },
-    nozzle_temp: { x: 41, y: 38, width: 25, height: 0, click_target: "target_nozzle_temperature" },
-    cover_image: { x: 41, y: 59, width: 250, height: 250 },
-    bed_temp: { x: 41, y: 80, width: 25, height: 0, click_target: "target_bed_temperature" },
-    print_progress: { x: 74, y: 89, width: 25, height: 0 },
+    power:          { x: 95, y: 9,  width: 20,  height: 0 },
+    chamber_light:  { x: 88, y: 29, width: 20,  height: 0 },
+    nozzle_temp:    { x: 41, y: 38, width: 25,  height: 0, click_target: "target_nozzle_temperature" },
+    cover_image:    { x: 41, y: 59, width: 42,  height: 42 },
+    bed_temp:       { x: 41, y: 80, width: 25,  height: 0, click_target: "target_bed_temperature" },
+    print_progress: { x: 74, y: 89, width: 25,  height: 0 },
     remaining_time: { x: 74, y: 93, width: 100, height: 0 },
-    stage: { x: 41, y: 93, width: 300, height: 0 },
+    stage:          { x: 41, y: 93, width: 300, height: 0 },
   };
 
   private P1PEntityUX: { [key: string]: EntityUX | undefined } = {
-    power: { x: 94, y: 5, width: 20, height: 0 },
-    print_progress: { x: 23, y: 3.5, width: 25, height: 0 },
+    power:          { x: 94, y: 5,   width: 20,  height: 0 },
+    print_progress: { x: 23, y: 3.5, width: 25,  height: 0 },
     remaining_time: { x: 59, y: 4.5, width: 100, height: 0 },
     //hms:                    { x: 90,   y:10,  width:20,  height:0 },
-    chamber_light: { x: 12, y: 19, width: 20, height: 0 },
-    nozzle_temp: { x: 50, y: 33, width: 25, height: 0, click_target: "target_nozzle_temperature" },
-    chamber_temp: { x: 86, y: 32, width: 20, height: 0 },
-    humidity: { x: 86, y: 42, width: 20, height: 0 },
-    aux_fan: { x: 12, y: 60, width: 70, height: 0 },
-    cover_image: { x: 50, y: 60, width: 50, height: 50 },
-    bed_temp: { x: 50, y: 86, width: 25, height: 0, click_target: "target_bed_temperature" },
-    stage: { x: 50, y: 94, width: 300, height: 0 },
+    chamber_light:  { x: 12, y: 19,  width: 20,  height: 0 },
+    nozzle_temp:    { x: 50, y: 33,  width: 25,  height: 0, click_target: "target_nozzle_temperature" },
+    chamber_temp:   { x: 86, y: 32,  width: 20,  height: 0 },
+    humidity:       { x: 86, y: 42,  width: 20,  height: 0 },
+    aux_fan:        { x: 12, y: 60,  width: 70,  height: 0 },
+    cover_image:    { x: 50, y: 60,  width: 50,  height: 50 },
+    bed_temp:       { x: 50, y: 86,  width: 25,  height: 0, click_target: "target_bed_temperature" },
+    stage:          { x: 50, y: 94,  width: 300, height: 0 },
   };
 
   private P1SEntityUX: { [key: string]: EntityUX | undefined } = {
     //hms:                    { x: 90, y:10,  width:20,  height:0 },
-    power: { x: 95, y: 5.5, width: 20, height: 0 },
-    print_progress: { x: 23, y: 4, width: 25, height: 0 },
-    remaining_time: { x: 59, y: 5, width: 100, height: 0 },
-    chamber_light: { x: 13, y: 21, width: 20, height: 0 },
-    chamber_fan: { x: 86, y: 21, width: 70, height: 0 },
-    nozzle_temp: { x: 50, y: 33, width: 25, height: 0, click_target: "target_nozzle_temperature" },
-    chamber_temp: { x: 86, y: 32, width: 20, height: 0 },
-    humidity: { x: 86, y: 42, width: 20, height: 0 },
-    aux_fan: { x: 13, y: 60, width: 70, height: 0 },
-    cover_image: { x: 50, y: 60, width: 50, height: 50 },
-    bed_temp: { x: 50, y: 88, width: 25, height: 0, click_target: "target_bed_temperature" },
-    stage: { x: 50, y: 95, width: 300, height: 0 },
+    power:          { x: 95, y: 5.5, width: 20,  height: 0 },
+    print_progress: { x: 23, y: 4,   width: 25,  height: 0 },
+    remaining_time: { x: 59, y: 5,   width: 100, height: 0 },
+    chamber_light:  { x: 13, y: 21,  width: 20,  height: 0 },
+    chamber_fan:    { x: 86, y: 21,  width: 70,  height: 0 },
+    nozzle_temp:    { x: 50, y: 33,  width: 25,  height: 0, click_target: "target_nozzle_temperature" },
+    chamber_temp:   { x: 86, y: 32,  width: 20,  height: 0 },
+    humidity:       { x: 86, y: 42,  width: 20,  height: 0 },
+    aux_fan:        { x: 13, y: 60,  width: 70,  height: 0 },
+    cover_image:    { x: 50, y: 60,  width: 50,  height: 50 },
+    bed_temp:       { x: 50, y: 88,  width: 25,  height: 0, click_target: "target_bed_temperature" },
+    stage:          { x: 50, y: 95,  width: 300, height: 0 },
   };
 
   private X1CEntityUX: { [key: string]: EntityUX | undefined } = {
     //hms:                    { x: 90, y:10, width:20,  height:0 },
-    power: { x: 95.5, y: 10, width: 20, height: 0 },
-    print_progress: { x: 29, y: 6, width: 25, height: 0 },
-    remaining_time: { x: 29, y: 11, width: 100, height: 0 },
-    chamber_light: { x: 13, y: 24, width: 20, height: 0 },
-    chamber_fan: { x: 86, y: 24, width: 70, height: 0 },
-    nozzle_temp: { x: 50, y: 31, width: 25, height: 0, click_target: "target_nozzle_temperature" },
-    chamber_temp: { x: 86, y: 33, width: 20, height: 0 },
-    humidity: { x: 86, y: 42, width: 20, height: 0 },
-    aux_fan: { x: 13, y: 60, width: 70, height: 0 },
-    cover_image: { x: 50, y: 60, width: 50, height: 50 },
-    bed_temp: { x: 50, y: 88, width: 25, height: 0, click_target: "target_bed_temperature" },
-    stage: { x: 50, y: 95, width: 300, height: 0 },
-    door_open: { x: 86, y: 60, width: 20, height: 0 },
+    power:          { x: 95.5, y: 10, width: 20,  height: 0 },
+    print_progress: { x: 29,   y: 6,  width: 25,  height: 0 },
+    remaining_time: { x: 29,   y: 11, width: 100, height: 0 },
+    chamber_light:  { x: 13,   y: 24, width: 20,  height: 0 },
+    chamber_fan:    { x: 86,   y: 24, width: 70,  height: 0 },
+    nozzle_temp:    { x: 50,   y: 31, width: 25,  height: 0, click_target: "target_nozzle_temperature" },
+    chamber_temp:   { x: 86,   y: 33, width: 20,  height: 0 },
+    humidity:       { x: 86,   y: 42, width: 20,  height: 0 },
+    aux_fan:        { x: 13,   y: 60, width: 70,  height: 0 },
+    cover_image:    { x: 50,   y: 60, width: 50,  height: 50 },
+    bed_temp:       { x: 50,   y: 88, width: 25,  height: 0, click_target: "target_bed_temperature" },
+    stage:          { x: 50,   y: 95, width: 300, height: 0 },
+    door_open:      { x: 86,   y: 60, width: 20,  height: 0 },
   };
 
   private EntityUX: { [key: string]: any } = {
@@ -180,6 +180,7 @@ export class PrintStatusCard extends EntityProvider {
       if (this._model == "A1 MINI") {
         this._model = "A1MINI";
       }
+      this._model = "A1MINI";
       this._entityUX = this.EntityUX[this._model];
     }
   }


### PR DESCRIPTION
## Description

Add back removed formatting so the UX arrangement is human readable again. And fix the missed change to the cover_image sizing for A1 and A1Mini models.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
