### PR TITLE
Fix ams mapping for reprints

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -298,7 +298,6 @@ export function isEntityStateUnknown(hass, entity: Entity): boolean {
 
 export function getImageUrl(hass, entity: Entity): string {
   if (isEntityUnavailable(hass, entity)) {
-    console.log("Image unavailable");
     return "";
   } else {
     const imageEntityId = entity.entity_id;


### PR DESCRIPTION
## Description
The original logic to create the ams mapping array was just utterly wrong. I don't know what I was smoking. It is much simpler than I had convinced myself.

It's just a list of mapping of 1-based filament ids from the slicer_info to the zero based global ams slot index.
So a print with slicer filament ids 2 & 3 printing from ams 2 slot 4 & ams 1 slot 2 respectively will need this ams mapping:
-1, 7, 1
unused, (1 * 4 + (4-1)), (0 * 4 + (2-1)

I do not yet know how AMS HT indexes should be computed. They might be the 128-based index of the AMS HT or they might need to be started after the last non-HT AMS. So single AMS + single AMS HT might have an idex of 4 for the HT tray/slot.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
