### PR TITLE
Default to showing compatible prints

### DIFF
--- a/src/cards/shared-components/print-history-popup/print-history-popup.ts
+++ b/src/cards/shared-components/print-history-popup/print-history-popup.ts
@@ -359,8 +359,8 @@ export class PrintHistoryPopup extends LitElement {
       <div class="print-history-controls">
         <div class="print-history-filters">
           <select class="printer-filter" @change=${(e) => { this._selectedPrinter = e.target.value; this._refreshFiles(); }}>
-            <option value="compatible">Compatible Prints</option>
             <option value="all">All Prints</option>
+            <option value="compatible">Compatible Prints</option>
             ${this._printerOptions.map(printer => html`
               <option value="${printer.serial}" ?selected=${this._selectedPrinter === printer.serial}>
                 ${printer.name}

--- a/src/cards/shared-components/print-history-popup/print-history-popup.ts
+++ b/src/cards/shared-components/print-history-popup/print-history-popup.ts
@@ -20,6 +20,11 @@ interface FileCacheFile {
   printer_model: string;
 }
 
+interface PrinterOption {
+  serial: string;
+  name: string;
+}
+
 @customElement("print-history-popup")
 export class PrintHistoryPopup extends LitElement {
   @property() public device_serial: string = "";
@@ -40,13 +45,19 @@ export class PrintHistoryPopup extends LitElement {
   @state() private _timelapseLoading: boolean = false;
   @state() private _timelapseError: string | null = null;
   @state() private _openTimelapseVideo: string | null = null;
-  @state() private _selectedPrinter: string = "all";
+  @state() private _selectedPrinter: string = "compatible";
   @state() private _allFiles: FileCacheFile[] = [];
   @state() private _allFilesSizeBytes: number = 0;
   @state() private _allTimelapseFiles: FileCacheFile[] = [];
   @state() private _allTimelapseFilesSizeBytes: number = 0;
 
+  private _allPrinters = new Set<string>();
+  private _compatiblePrinters = new Set<string>();
+  private _printerOptions: PrinterOption[] = [];
+
   @query('print-settings-popup') private _overlay!: PrintSettingsPopup;
+
+  private _model: string = "";
 
   private _thumbnailUrls = new Map<string, string | null>();
   private _thumbnailLoading: Map<string, Promise<string | null>> = new Map();
@@ -57,6 +68,7 @@ export class PrintHistoryPopup extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+    this.#initializeModel();
     this._updateContent();
   }
 
@@ -72,7 +84,7 @@ export class PrintHistoryPopup extends LitElement {
   }
 
   show() {
-    this._selectedPrinter = "all";
+    this._selectedPrinter = "compatible";
     this.#changeTab(0);
     this._show = true;
     document.body.style.overflow = 'hidden';
@@ -90,6 +102,15 @@ export class PrintHistoryPopup extends LitElement {
     }
 
     this.requestUpdate();
+  }
+
+  #initializeModel() {
+    if (!this._model) {
+      this._model = this._hass.devices[this.device_id!]?.model?.toUpperCase() || "";
+      if (this._model == "A1 MINI") {
+        this._model = "A1MINI";
+      }
+    }
   }
 
   #formatBytesRounded(bytes: number): string {
@@ -133,7 +154,13 @@ export class PrintHistoryPopup extends LitElement {
         this._allFilesSizeBytes = result.total_size_bytes;
         // Filter by selected printer if not "all"
         let filteredFiles = result.files;
-        if (this._selectedPrinter !== "all") {
+        if (this._selectedPrinter === "all") {
+          // Leave all entries in the list.
+        } else if (this._selectedPrinter === "compatible") {
+          filteredFiles = result.files.filter((file: FileCacheFile) =>
+            helpers.areModelsCompatible(this._model, file.printer_model)
+          );
+        } else {
           filteredFiles = result.files.filter((file: FileCacheFile) =>
             file.printer_serial === this._selectedPrinter
           );
@@ -143,11 +170,33 @@ export class PrintHistoryPopup extends LitElement {
     } catch (error) {
       console.error('[FileCachePopup] _refreshFiles() - error:', error);
       this._error = error instanceof Error ? error.message : String(error);
-      this.requestUpdate();
-    } finally {
-      this._loading = false;
-      this.requestUpdate();
     }
+    
+    // Get unique printers for filter dropdown from all unfiltered data
+    this._allPrinters = new Set<string>();
+    this._compatiblePrinters = new Set<string>();
+    this._allFiles.forEach(file => {
+      this._allPrinters.add(file.printer_serial);
+      if (helpers.areModelsCompatible(this._model, file.printer_model)) {
+        this._compatiblePrinters.add(file.printer_serial)
+      }
+    });
+    this._allTimelapseFiles.forEach(file => {
+      this._allPrinters.add(file.printer_serial);
+      if (helpers.areModelsCompatible(this._model, file.printer_model)) {
+        this._compatiblePrinters.add(file.printer_serial)
+      }
+    });
+
+    this._printerOptions = Array.from(this._allPrinters).map(serial => ({
+      serial,
+      name: this._allFiles.find(f => f.printer_serial === serial)?.printer_name ||
+            this._allTimelapseFiles.find(f => f.printer_serial === serial)?.printer_name ||
+            serial
+    }));
+
+    this._loading = false;
+    this.requestUpdate();
   }
 
   async _refreshTimelapseFiles() {
@@ -288,21 +337,6 @@ export class PrintHistoryPopup extends LitElement {
       return nothing;
     }
 
-    // Get unique printers for filter dropdown from all unfiltered data
-    const allPrinters = new Set<string>();
-    this._allFiles.forEach(file => {
-      if (file.printer_serial) allPrinters.add(file.printer_serial);
-    });
-    this._allTimelapseFiles.forEach(file => {
-      if (file.printer_serial) allPrinters.add(file.printer_serial);
-    });
-    const printerOptions = Array.from(allPrinters).map(serial => ({
-      serial,
-      name: this._allFiles.find(f => f.printer_serial === serial)?.printer_name ||
-            this._allTimelapseFiles.find(f => f.printer_serial === serial)?.printer_name ||
-            serial
-    }));
-
     // Tab bar
     const tabLabels = ["Print History", "Timelapse Videos"];
     const renderTabs = html`
@@ -325,8 +359,9 @@ export class PrintHistoryPopup extends LitElement {
       <div class="print-history-controls">
         <div class="print-history-filters">
           <select class="printer-filter" @change=${(e) => { this._selectedPrinter = e.target.value; this._refreshFiles(); }}>
-            <option value="all">All Printers</option>
-            ${printerOptions.map(printer => html`
+            <option value="compatible">Compatible Prints</option>
+            <option value="all">All Prints</option>
+            ${this._printerOptions.map(printer => html`
               <option value="${printer.serial}" ?selected=${this._selectedPrinter === printer.serial}>
                 ${printer.name}
               </option>
@@ -402,7 +437,7 @@ export class PrintHistoryPopup extends LitElement {
         <div class="print-history-filters">
           <select class="printer-filter" @change=${(e) => { this._selectedPrinter = e.target.value; this._refreshTimelapseFiles(); }}>
             <option value="all">All Printers</option>
-            ${printerOptions.map(printer => html`
+            ${this._printerOptions.map(printer => html`
               <option value="${printer.serial}" ?selected=${this._selectedPrinter === printer.serial}>
                 ${printer.name}
               </option>

--- a/src/cards/shared-components/print-history-popup/print-history-popup.ts
+++ b/src/cards/shared-components/print-history-popup/print-history-popup.ts
@@ -359,8 +359,8 @@ export class PrintHistoryPopup extends LitElement {
       <div class="print-history-controls">
         <div class="print-history-filters">
           <select class="printer-filter" @change=${(e) => { this._selectedPrinter = e.target.value; this._refreshFiles(); }}>
-            <option value="all">All Prints</option>
-            <option value="compatible">Compatible Prints</option>
+            <option value="all" ?selected=${this._selectedPrinter === "all"}>All Prints</option>
+            <option value="compatible" ?selected=${this._selectedPrinter === "compatible"}>Compatible Prints</option>
             ${this._printerOptions.map(printer => html`
               <option value="${printer.serial}" ?selected=${this._selectedPrinter === printer.serial}>
                 ${printer.name}

--- a/src/cards/shared-components/print-history-popup/print-settings-popup.ts
+++ b/src/cards/shared-components/print-history-popup/print-settings-popup.ts
@@ -578,17 +578,6 @@ export class PrintSettingsPopup extends LitElement {
     return device?.model || null;
   }
 
-  // Helper to check if two models are compatible (P1P, P1S, X1C, X1E are equivalent)
-  private _areModelsCompatible(modelA: string | null, modelB: string | null): boolean {
-    if (!modelA || !modelB) return false;
-    const eqSet = ["P1P", "P1S", "X1C", "X1E"];
-    const normA = modelA.trim().toUpperCase();
-    const normB = modelB.trim().toUpperCase();
-    if (eqSet.includes(normA) && eqSet.includes(normB)) return true;
-    return normA === normB;
-  }
-
-
   render() {
     return html`
       <div class="print-settings-overlay" @click=${this._hidePrintDialog}>
@@ -620,7 +609,7 @@ export class PrintSettingsPopup extends LitElement {
                   const normFile = (fileModel || '').trim().toUpperCase();
                   const normCurrent = (currentModel || '').trim().toUpperCase();
                   if (fileModel && currentModel) {
-                    if (!this._areModelsCompatible(fileModel, currentModel)) {
+                    if (!helpers.areModelsCompatible(fileModel, currentModel)) {
                       return html`<div style="color: var(--error-color, #f44336); margin-top: 8px; font-weight: bold;">This print is incompatible with the selected printer model (${fileModel} vs ${currentModel}).</div>`;
                     } else if (
                       eqSet.includes(normFile) && eqSet.includes(normCurrent) && normFile !== normCurrent
@@ -718,7 +707,7 @@ export class PrintSettingsPopup extends LitElement {
                       if (this.selected_file) {
                         const fileModel = this.selected_file.printer_model;
                         const currentModel = this._getCurrentPrinterModel();
-                        if (fileModel && currentModel && !this._areModelsCompatible(fileModel, currentModel)) {
+                        if (fileModel && currentModel && !helpers.areModelsCompatible(fileModel, currentModel)) {
                           return true;
                         }
                       }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -377,3 +377,15 @@ export function getFormattedTime(hass, entity_id) {
       seconds: Math.floor(seconds % 60),
     });
 }
+
+// Helper to check if two models are compatible (P1P, P1S, X1C, X1E are equivalent)
+export function areModelsCompatible(modelA: string, modelB: string): boolean {
+    const eqSet = ["P2S", "P1P", "P1S", "X1C", "X1E"];
+    // TO BE DETERMINED:
+    // Is H2C compatible with H2D?
+    // Is P2S really compatible given it has a different filament cutter?
+    const normA = modelA.trim().toUpperCase();
+    const normB = modelB.trim().toUpperCase();
+    if (eqSet.includes(normA) && eqSet.includes(normB)) return true;
+    return normA === normB;
+}


### PR DESCRIPTION
## Description

With a heterogenous mix of printers like A1s and P1s there is limited value in showing all prints when we will block print for the other incompatible type. Switch to filtering the starting list to compatible prints. There is an all prints option still that gives the old behavior so you can quickly look up a print if you expected to see it in order to find out which printer/type it was printed to.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
