### PR TITLE
Show state when printing for simple card

### DIFF
--- a/src/cards/print-status-card/a1-screen/a1-screen-card.ts
+++ b/src/cards/print-status-card/a1-screen/a1-screen-card.ts
@@ -362,13 +362,14 @@ export class A1ScreenCard extends LitElement {
     const printStatusState = this._hass.states[printStatusRef.entity_id]?.state;
 
     if (printStatusState === "running") {
+      const stage = stageRef ? this._hass.states[stageRef.entity_id]?.state : "printing";
       const currentLayerRef = this._deviceEntities?.["current_layer"];
       const totalLayersRef = this._deviceEntities?.["total_layers"];
 
       const currentLayer = currentLayerRef ? this._hass.states[currentLayerRef.entity_id]?.state : "";
       const totalLayers = totalLayersRef ? this._hass.states[totalLayersRef.entity_id]?.state : "";
 
-      if (currentLayer !== "" && totalLayers !== "") {
+      if (currentLayer !== "" && totalLayers !== "" && (stage === "printing" || (currentLayer > 0 && currentLayer < totalLayers))) {
         return `${currentLayer}/${totalLayers}`;
       }
     }


### PR DESCRIPTION
## Description

Printer has many stage before and after print such as heating chamber, calibration, purifying chamber air,... etc
Currently it will stuck at 0 layer without extra information.
I think it's better to show all stage.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] New feature
  - Show stage even when print status is running

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
