### PR TITLE
Fix device details page opening in browser on mobile

### DIFF
--- a/src/cards/print-status-card/a1-screen/a1-screen-card.ts
+++ b/src/cards/print-status-card/a1-screen/a1-screen-card.ts
@@ -516,7 +516,12 @@ export class A1ScreenCard extends LitElement {
   #openDevicePage() {
     if (!this._device_id) return;
     const url = `/config/devices/device/${this._device_id}`;
-    window.location.href = url;
+    history.pushState(null, "", url);
+    window.dispatchEvent(
+      new CustomEvent("location-changed", {
+        detail: { replace: false },
+      })
+    );
   }
 
   #showFileCache() {


### PR DESCRIPTION
## Description

This fixed the navigation that's done when clicking the "Show Home Assistant device page" in the "Simple" print statue card. Instead of doing `window.location.href`, which causes a full page navigation, we instead do an SPA navigation like all over navigation in Home Assistant is done. The implementation is based on [custom-card-helpers's navigate implementation](https://github.com/custom-cards/custom-card-helpers/blob/master/src/navigate.ts).

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->

The biggest issue with using `href` (for me) is that it opens a browser when clicked from the Home Assistant companion app, rather than opening the device details page in the app. This fixed that (tested manually on Android, app version 2026.4.4). It also fixes the full page reload that happens when clicking it in a desktop browser, instead doing an SPA transition, which is a much nicer experience.