### PR TITLE
Avoid stale cover image reloads

### DIFF
--- a/src/cards/print-status-card/a1-screen/a1-screen-card.ts
+++ b/src/cards/print-status-card/a1-screen/a1-screen-card.ts
@@ -41,6 +41,8 @@ interface AMS {
   spools: string[];
 }
 
+const processedCoverImages = new Map<string, { source: string; image: string }>();
+
 @customElement("a1-screen-card")
 export class A1ScreenCard extends LitElement {
   @property() public coverImage;
@@ -52,6 +54,8 @@ export class A1ScreenCard extends LitElement {
   @property() public showCoverPosition: "left" | "right" = "left";
   @property() public showCameraPosition: "left" | "right" = "right";
   @state() private processedImage: string | null = null;
+  private processedImageSource: string | undefined;
+  private processingImageSource: string | undefined;
   @state() private minimalCoverImageFailed = false;
   @state() private minimalCameraImageFailed = false;
   @state() private showExtraControls = false;
@@ -91,8 +95,7 @@ export class A1ScreenCard extends LitElement {
 
   static styles = styles;
 
-  async #processCoverImage() {
-    if (!this.coverImage) return null;
+  async #processCoverImage(source: string) {
 
     return new Promise<string>((resolve) => {
       const img = new Image();
@@ -161,26 +164,58 @@ export class A1ScreenCard extends LitElement {
       };
 
       img.onerror = () => {
-        resolve(this.coverImage);
+        resolve("");
       };
 
-      img.src = this.coverImage;
+      img.src = source;
     });
+  }
+
+  async #updateCoverImage() {
+    const source = this.coverImage;
+    const cachedImage = processedCoverImages.get(this._device_id);
+
+    if (cachedImage && cachedImage.source === source) {
+      this.processedImage = cachedImage.image;
+      this.processedImageSource = source;
+      return;
+    }
+
+    if (
+      !source ||
+      source === this.processedImageSource ||
+      source === this.processingImageSource
+    ) {
+      return;
+    }
+
+    this.processingImageSource = source;
+    const processedImage = await this.#processCoverImage(source);
+
+    if (this.coverImage === source) {
+      this.processedImage = processedImage;
+      this.processedImageSource = source;
+      if (processedImage) {
+        processedCoverImages.set(this._device_id, { source, image: processedImage });
+      }
+    }
+
+    if (this.processingImageSource === source) {
+      this.processingImageSource = undefined;
+    }
   }
 
   async firstUpdated(changedProperties): Promise<void> {
     super.firstUpdated(changedProperties);
     this.observeCardHeight();
-    this.processedImage = await this.#processCoverImage();
+    await this.#updateCoverImage();
 
     this.#getAMSList();
   }
 
   updated(changedProperties) {
     if (changedProperties.has("coverImage")) {
-      this.#processCoverImage().then((processedImage) => {
-        this.processedImage = processedImage;
-      });
+      this.#updateCoverImage();
     }
 
     if (changedProperties.has("coverImage") || changedProperties.has("processedImage")) {
@@ -263,7 +298,7 @@ export class A1ScreenCard extends LitElement {
   #renderMinimalCoverTile() {
     if (!this.showCover) return nothing;
 
-    const coverSrc = this.processedImage || this.coverImage || "";
+    const coverSrc = this.processedImage || "";
     const showCoverImage = !!coverSrc && !this.minimalCoverImageFailed;
     return html`
       <div class="ha-bambulab-ssc-minimal-cover">
@@ -704,7 +739,7 @@ export class A1ScreenCard extends LitElement {
 
   #renderFrontPage() {
 
-    const coverSrc = this.processedImage || this.coverImage || "";
+    const coverSrc = this.processedImage || "";
     const showCoverImage = !!coverSrc && !this.simpleCoverImageFailed;
 
     let videoHtml: any = nothing

--- a/src/cards/print-status-card/print-status-card.ts
+++ b/src/cards/print-status-card/print-status-card.ts
@@ -390,8 +390,15 @@ export class PrintStatusCard extends EntityProvider {
   updated(changedProperties) {
     super.updated(changedProperties);
 
-    if (changedProperties.has("_hass")) {
-      this._coverImageUrl = helpers.getImageUrl(this._hass, this._deviceEntities["cover_image"]);
+    if (changedProperties.has("_hass") && this._hass.connected) {
+      const coverImageUrl = helpers.getImageUrl(this._hass, this._deviceEntities["cover_image"]);
+
+      // Home Assistant supplies its last state snapshot while reconnecting. Keep
+      // the already-rendered image until a new image URL arrives, rather than
+      // asking the browser to fetch an image using that stale token.
+      if (coverImageUrl && coverImageUrl !== this._coverImageUrl) {
+        this._coverImageUrl = coverImageUrl;
+      }
     }
   }
 


### PR DESCRIPTION
Currently, if a Bambu status card is open and showing a cover image and you restart HA, you are likely to get an authentication error showing up in the HA notifications, because of a stale image URL being requested when HA reconnects.

## PR Summary

- retain each printer's processed cover image across reconnect-driven card recreation
- only load a cover image when Home Assistant supplies a new image URL
- avoid rendering the raw source URL while the card is processing it

## Root cause

When Home Assistant reconnects after a restart, the card can be recreated with its last state snapshot. The old image URL contains an in-memory Home Assistant token which is invalid after the restart. The recreated card therefore fetched the stale URL, resulting in an invalid-authentication warning.

The processed image is now cached in the loaded card module by printer and source URL. A recreated card reuses it until a different source URL is received. Failed image loads are not cached.

## Validation

`npm run build:strict`
