### PR TITLE
Fix missing Confirm/Cancel buttons on print control confirmation dialog

### DIFF
--- a/src/cards/print-control-card/print-control-card.ts
+++ b/src/cards/print-control-card/print-control-card.ts
@@ -453,6 +453,8 @@ export class PrintControlCard extends LitElement {
             <div slot="title">Please confirm</div>
           </ha-dialog-header>
           <div class="content">${this._confirmationDialogBody}</div>
+
+          <!-- Needed in older home assistant versions that don't support ha-button in dialog actions -->
           <mwc-button
             slot="primaryAction"
             @click="${() => {
@@ -468,6 +470,25 @@ export class PrintControlCard extends LitElement {
             }}"
             >Cancel</mwc-button
           >
+
+          <ha-dialog-footer slot="footer">
+            <!-- For newer home assistant versions that support ha-button in dialog actions -->
+            <ha-button
+              slot="primaryAction"
+              @click="${() => {
+                this.#confirmationAction();
+                this._confirmationDialogVisible = false;
+              }}"
+              >Confirm</ha-button
+            >
+            <ha-button
+              slot="secondaryAction"
+              @click="${() => {
+                this._confirmationDialogVisible = false;
+              }}"
+              >Cancel</ha-button
+            >
+          </ha-dialog-footer>
         </ha-dialog>
       `;
     }


### PR DESCRIPTION
## Symptom

Relates to greghesp/ha-bambulab#2024 ("[Bug] No Buttons in Print Control Card") and its duplicate greghesp/ha-bambulab#2048 ("Confirmation dialog (Pause/Stop) shows no visible action buttons since v0.6.51").

Clicking Pause or Stop on the Print Control card opens a confirmation dialog whose Confirm/Cancel buttons don't render visually (though they exist in the DOM per #2048's own DevTools inspection). Users have to blindly click behind the dialog on the underlying Pause/Stop icon to proceed.

## Root cause

[`src/cards/print-control-card/print-control-card.ts`](https://github.com/greghesp/ha-bambulab-cards/blob/main/src/cards/print-control-card/print-control-card.ts), method `#populateConfirmationDialog()`.

This dialog has its own separate `<ha-dialog>` markup (distinct from the shared `<confirmation-prompt>` component) and only ever rendered `<mwc-button slot="primaryAction">` / `<mwc-button slot="secondaryAction">`. Newer Home Assistant versions changed how dialog action buttons are rendered/styled and no longer display bare `mwc-button` elements placed in those slots.

This exact class of bug was already fixed once, in the shared `confirmation-prompt.ts` component, via #140 (which switched to `<ha-dialog-footer slot="footer"><ha-button .../></ha-dialog-footer>`) and #142 (which restored the `mwc-button` fallback for older HA versions that don't support `ha-button` in dialog actions). As AdrianGarside noted on #2024: *"Ah, looks like the fix I made for the home assistant button element breaking changes wasn't done in enough places."* — `print-control-card.ts`'s own dialog markup was the place that got missed.

I confirmed by grepping for `mwc-button` across `src/`: the only two dialog-action-slot occurrences (`slot="primaryAction"`/`slot="secondaryAction"` inside an `<ha-dialog>`) are `confirmation-prompt.ts` (already fixed, has both variants) and `print-control-card.ts` (this PR). There are other `mwc-button` usages in `ams-popup.ts`, but those render inside the dialog body (`hideactions` mode, regular content buttons), not in `primaryAction`/`secondaryAction` slots, so they're a different code path and out of scope here.

## What changed

Added the same `<ha-dialog-footer slot="footer">` + `<ha-button>` block (for newer HA) alongside the existing `<mwc-button>` fallback (for older HA) to `print-control-card.ts`'s confirmation dialog — mirroring exactly what `confirmation-prompt.ts` already does.

## What I validated

- `npm ci && npm run build:strict` (the same command this repo's `Frontend Build Check` CI workflow runs) completes with no TypeScript or build errors, on Node v25.9.0 locally (CI pins Node 20 — I don't have that version available locally, so the authoritative check is still this PR's CI run).
- Inspected the built `dist/ha-bambulab-cards.js` output and confirmed the new `ha-dialog-footer` / `ha-button` markup is present in the compiled bundle for this dialog.
- I do **not** have a way to load this bundle into a live Home Assistant instance to visually confirm the buttons now render, since I don't have a Bambu Lab printer or an HA dev environment set up. The fix is a straight structural mirror of the already-shipped, working fix in `confirmation-prompt.ts`, so I'm confident in the approach, but this hasn't been visually verified in a browser.

## Note on the vendored bundle in `ha-bambulab`

I noticed `greghesp/ha-bambulab`'s `custom_components/bambu_lab/frontend/ha-bambulab-cards.js` is a synced build artifact (per `.github/workflows/release.yaml` here, it's only updated automatically when a GitHub Release is cut on this repo). I intentionally did **not** hand-build and commit an updated bundle into `ha-bambulab` myself — that pipeline is release-gated and requires a `PR_TOKEN` I don't have, and manually short-circuiting it seemed more likely to cause confusion than help. Once this is merged and released here, the existing automation should pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)